### PR TITLE
bugfix: make division required as unseting division makes problems

### DIFF
--- a/templates/default/numberplan/numberplanadd.html
+++ b/templates/default/numberplan/numberplanadd.html
@@ -65,7 +65,7 @@
 				{trans("Division")}
 			</TD>
 			<TD>
-				<select name="numberplanadd[divisions][]" id="divisions" multiple
+				<select name="numberplanadd[divisions][]" id="divisions" multiple required
 						{tip text="Select division" class="lms-ui-multiselect" trigger="divisions"}>
 					{foreach $divisions as $division}
 						<option value="{$division.id}"{if isset($numberplanadd.divisions[$division.id])} selected{/if}

--- a/templates/default/numberplan/numberplanedit.html
+++ b/templates/default/numberplan/numberplanedit.html
@@ -63,7 +63,7 @@
 				{trans("Division")}
 			</TD>
 			<TD>
-				<select name="numberplanedit[divisions][]" id="divisions" multiple
+				<select name="numberplanedit[divisions][]" id="divisions" multiple required
 					{tip text="Select division" class="lms-ui-multiselect" trigger="divisions"}>
 					{foreach $divisions as $division}
 						<option value="{$division.id}"{if isset($numberplanedit.divisions[$division.id])} selected{/if}


### PR DESCRIPTION
Przypisanie planu numeracyjnego naprawia to problem błędnej numeracji generowanych dokumentów - więc ten powinien być wymagany. Nieprzypisanie planu numeracyjnego powoduje wzięcie domyślnej numeracji %N/LMS.