### PR TITLE
bugfix: not verticaly centered items in columns

### DIFF
--- a/css/style.less
+++ b/css/style.less
@@ -2429,6 +2429,8 @@ div.lms-ui-tab-container {
 	.lms-ui-tab-table-column {
 		padding-left: 0.5em;
 		text-overflow: ellipsis;
+		display: inline-flex;
+		align-items: center;
 		&.buttons {
 			text-align: right;
 			display: flex;


### PR DESCRIPTION
Przed:
![before](https://user-images.githubusercontent.com/17087236/129736218-cc9723b4-1e04-4d38-b8e6-4a099097a8f4.png)

Po:
![after](https://user-images.githubusercontent.com/17087236/129736233-b5d81eec-cb42-4cc7-b3cb-f39bc967dc10.png)