### PR TITLE
bugfix: remove php warning

### DIFF
--- a/modules/quicksearch.php
+++ b/modules/quicksearch.php
@@ -1055,7 +1055,7 @@ switch ($mode) {
 			FROM documents d
 			JOIN customerview c ON c.id = d.customerid
 			WHERE LOWER(fullnumber) ?LIKE? LOWER($sql_search)");
-        if (count($docs) == 1) {
+        if (isset($docs) && count($docs) == 1) {
             $cid = $docs[0]['cid'];
 /*
             $docid = $docs[0]['id'];

--- a/modules/quicksearch.php
+++ b/modules/quicksearch.php
@@ -1055,7 +1055,7 @@ switch ($mode) {
 			FROM documents d
 			JOIN customerview c ON c.id = d.customerid
 			WHERE LOWER(fullnumber) ?LIKE? LOWER($sql_search)");
-        if (isset($docs) && count($docs) == 1) {
+        if (!empty($docs) && count($docs) == 1) {
             $cid = $docs[0]['cid'];
 /*
             $docid = $docs[0]['id'];


### PR DESCRIPTION
Powyższy commit usuwa ostrzeżenie w logach:
`PHP Warning:  count(): Parameter must be an array or an object that implements Countable in /var/www/html/dev-lms/modules/quicksearch.php on line 1058, referer: https://dev-lms.interduo.pl/?m=netdevsearch&search`