### PR TITLE
Revert "devel/travis: distabled test builds on php 8.0 (spipu/html2pd…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,14 @@ matrix:
         PHPCS_STANDARD="phpcs3.xml"
         INSTALL_PHP_ZIP_EXTENSION=true
 
-#    - os: linux
-#      language: php
-#      php: 8.0
-#      dist: xenial
-#      env:
-#        PHPCS_VER="^3"
-#        PHPCS_STANDARD="phpcs3.xml"
-#        INSTALL_PHP_ZIP_EXTENSION=true
+    - os: linux
+      language: php
+      php: 8.0
+      dist: xenial
+      env:
+        PHPCS_VER="^3"
+        PHPCS_STANDARD="phpcs3.xml"
+        INSTALL_PHP_ZIP_EXTENSION=true
 
 addons:
   postgresql: 9.4


### PR DESCRIPTION
…f does not support PHP 8.0)" - now it supports php 8.0

This reverts commit 7b5a9e57f1a9caa7e59aa0e006fc2ca9ba14e24e.