### PR TITLE
bugfix: fix db migrations

### DIFF
--- a/lib/upgradedb/mysql.2015100100.php
+++ b/lib/upgradedb/mysql.2015100100.php
@@ -64,7 +64,7 @@ $rightmap = array(
 );
 
 $users = $this->GetAll("SELECT id, rights FROM users");
-foreach ($users as $user) {
+foreach ((array) $users as $user) {
     $mask = $user['rights'];
     $len = strlen($mask);
     $bin = '';

--- a/lib/upgradedb/mysql.2021050701.php
+++ b/lib/upgradedb/mysql.2021050701.php
@@ -28,8 +28,8 @@ if (!$this->ResourceExists('vcustomerassignments', LMSDB::RESOURCE_TYPE_VIEW)) {
     $this->Execute("ALTER TABLE customerassignments ADD COLUMN enddate int(11) DEFAULT 0 NOT NULL");
     $this->Execute("CREATE INDEX customerassignments_startdate_idx ON customerassignments (startdate)");
     $this->Execute("CREATE INDEX customerassignments_enddate_idx ON customerassignments (enddate)");
-    $this->Execute("ALTER TABLE customerassignments DROP CONSTRAINT customerassignment");
     $this->Execute("ALTER TABLE customerassignments ADD CONSTRAINT customerassignments_customergroupid_ukey UNIQUE (customergroupid, customerid, enddate)");
+    $this->Execute("ALTER TABLE customerassignments DROP CONSTRAINT customerassignment");
     $this->Execute("
         CREATE VIEW vcustomerassignments AS
             SELECT ca.*

--- a/lib/upgradedb/postgres.2015100100.php
+++ b/lib/upgradedb/postgres.2015100100.php
@@ -64,7 +64,7 @@ $rightmap = array(
 );
 
 $users = $this->GetAll("SELECT id, rights FROM users");
-foreach ($users as $user) {
+foreach ((array) $users as $user) {
     $mask = $user['rights'];
     $len = strlen($mask);
     $bin = '';

--- a/lib/upgradedb/postgres.2021050701.php
+++ b/lib/upgradedb/postgres.2021050701.php
@@ -29,8 +29,8 @@ if (!$this->ResourceExists('vcustomerassignments', LMSDB::RESOURCE_TYPE_VIEW)) {
         ALTER TABLE customerassignments ADD COLUMN enddate integer DEFAULT 0 NOT NULL;
         CREATE INDEX customerassignments_startdate_idx ON customerassignments (startdate);
         CREATE INDEX customerassignments_enddate_idx ON customerassignments (enddate);
-        ALTER TABLE customerassignments DROP CONSTRAINT customerassignments_customergroupid_key;
         ALTER TABLE customerassignments ADD CONSTRAINT customerassignments_customergroupid_ukey UNIQUE (customergroupid, customerid, enddate);
+        ALTER TABLE customerassignments DROP CONSTRAINT customerassignments_customergroupid_key;
         CREATE VIEW vcustomerassignments AS
             SELECT ca.*
             FROM customerassignments ca


### PR DESCRIPTION
Fix minor DB update issue:
PHP Warning:  Invalid argument supplied for foreach() in /var/www/lib/upgradedb/mysql.2015100100.php on line 67

Fix issue with customerassignment constraint on 2021050701 migration:
ALTER TABLE customerassignments DROP CONSTRAINT customerassignment
Cannot drop index 'customerassignment': needed in a foreign key constraint