### PR TITLE
bugfix: don't check duplicates for ten and ssn when it didn't changed

### DIFF
--- a/lib/LMS.class.php
+++ b/lib/LMS.class.php
@@ -856,6 +856,18 @@ class LMS
         return $manager->getCustomerPin($id);
     }
 
+    public function getCustomerTen($id)
+    {
+        $manager = $this->getCustomerManager();
+        return $manager->getCustomerTen($id);
+    }
+
+    public function getCustomerSsn($id)
+    {
+        $manager = $this->getCustomerManager();
+        return $manager->getCustomerSsn($id);
+    }
+
     public function changeCustomerType($id, $type)
     {
         $manager = $this->getCustomerManager();

--- a/lib/LMSManagers/LMSCustomerManager.php
+++ b/lib/LMSManagers/LMSCustomerManager.php
@@ -2941,6 +2941,16 @@ class LMSCustomerManager extends LMSManager implements LMSCustomerManagerInterfa
         return $this->db->GetOne('SELECT pin FROM customers WHERE id = ?', array($id));
     }
 
+    public function getCustomerTen($id)
+    {
+        return $this->db->GetOne('SELECT ten FROM customers WHERE id = ?', array($id));
+    }
+
+    public function getCustomerSsn($id)
+    {
+        return $this->db->GetOne('SELECT ssn FROM customers WHERE id = ?', array($id));
+    }
+
     public function changeCustomerType($id, $type)
     {
         $this->db->Execute(

--- a/lib/LMSManagers/LMSCustomerManagerInterface.php
+++ b/lib/LMSManagers/LMSCustomerManagerInterface.php
@@ -138,6 +138,10 @@ interface LMSCustomerManagerInterface
 
     public function getCustomerPin($id);
 
+    public function getCustomerTen($id);
+
+    public function getCustomerSsn($id);
+
     public function changeCustomerType($id, $tyoe);
 
     public function getCustomerCalls(array $params);

--- a/modules/customeredit.php
+++ b/modules/customeredit.php
@@ -217,7 +217,7 @@ if (!isset($_POST['xjxfun'])) {
                 }
             }
 
-            if ($customerdata['ten'] != '') {
+            if ($customerdata['ten'] != '' && $customerdata['ten'] != $LMS->GetCustomerTen($_GET['id'])) {
                 if (!isset($customerdata['tenwarning']) && !check_ten($customerdata['ten'])) {
                     $warning['ten'] = trans('Incorrect Tax Exempt Number! If you are sure you want to accept it, then click "Submit" again.');
                     $tenwarning = 1;
@@ -247,7 +247,7 @@ if (!isset($_POST['xjxfun'])) {
                 }
             }
 
-            if ($customerdata['ssn'] != '') {
+            if ($customerdata['ssn'] != '' && $customerdata['ssn'] != $LMS->getCustomerSsn($_GET['id'])) {
                 if (!isset($customerdata['ssnwarning']) && !check_ssn($customerdata['ssn'])) {
                     $warning['ssn'] = trans('Incorrect Social Security Number! If you are sure you want to accept it, then click "Submit" again.');
                     $ssnwarning = 1;

--- a/modules/customeredit.php
+++ b/modules/customeredit.php
@@ -217,7 +217,7 @@ if (!isset($_POST['xjxfun'])) {
                 }
             }
 
-            if ($customerdata['ten'] != '' && $customerdata['ten'] != $LMS->GetCustomerTen($_GET['id'])) {
+            if ($customerdata['ten'] != '' && $customerdata['ten'] != $LMS->getCustomerTen($_GET['id'])) {
                 if (!isset($customerdata['tenwarning']) && !check_ten($customerdata['ten'])) {
                     $warning['ten'] = trans('Incorrect Tax Exempt Number! If you are sure you want to accept it, then click "Submit" again.');
                     $tenwarning = 1;


### PR DESCRIPTION
…stence_check when it didn't changed


Rozwiązuje problem niemożliwości edycji danych klienta w przypadku kiedy:
- kontrola duplikatów została włączona w momencie gdy w bazie mamy już duplikaty,
- edytujemy klienta, który ma co najmniej 1 duplikat,
- `phpui.customer_ten_existence_check = error`

Ta sama sytuacja tyczy się sprawdzania duplikatów numerów PESEL.
Myślę, że to warto wrzucić to do wszystkich wspieranych gałęzi.