### PR TITLE
bugfix: not optional tarrifs - was marked as optional

### DIFF
--- a/templates/default/customer/customerassignmenthelper.html
+++ b/templates/default/customer/customerassignmenthelper.html
@@ -308,7 +308,9 @@
 																<table>
 																	<tr class="schema-tariff-container-row">
 																		<td>
-																			<select class="schema-tariff-selection" name="{$variable_prefix}[sassignmentid][{$schemaid}][{$label}]" data-label="{$label}">
+																			<select class="schema-tariff-selection" name="{$variable_prefix}[sassignmentid][{$schemaid}][{$label}]"
+																			    data-label="{$label}" {if $item.selection.required}required{/if}>
+																				<option value="" hidden>{trans("Select tariff")}</option>
 																				{if !$item.selection.required}
 																				<option value="0" data-tariffaccess="-1" data-tarifftype="0">{trans("- none -")}</option>
 																				{/if}


### PR DESCRIPTION
Motywacją tego PR było to, że:
- ciężko odróżnić wizualnie grupy taryf wymaganych od opcjonalnych,
- w przeszłości dochodziło często do błędów polegających na braku dokonania wyboru w grupie taryf z wyborem wymaganym
(do bazy i na dokument - trafiała pierwsza opcja z selecta wyboru (często omyłkowa) - zamiast jawnie dokonanego wyboru)