### PR TITLE
improvement: better placement of karma counter - moved away from cust…

### DIFF
--- a/templates/default/customer/customerinfobox.html
+++ b/templates/default/customer/customerinfobox.html
@@ -56,10 +56,10 @@
 						{icon name="customer" class="{if $customerpanel} lms-ui-sortable-handle{/if}"}
 						{if $customerpanel}{trans("Owner:")}{/if}
 						{$customerinfo.customername|escape} ({$customerinfo.id|string_format:"%04d"}{if $customerinfo.extid} / {$customerinfo.extid|escape}{/if})
-						{karma title="Karma" value=$customerinfo.karma handler="?m=customeredit&id={$customerinfo.id}&op=changekarma"}
 						{if $customerinfo.deleted} <span class="lms-ui-alert">({trans("deleted customer")})</span>{/if}
 					</div>
 					<div>
+						{karma title="Karma" value=$customerinfo.karma handler="?m=customeredit&id={$customerinfo.id}&op=changekarma"}
 						{if $customerpanel}<a href="?m=customerinfo&amp;id={$customerinfo.id}">{trans('Navigate to the customer')} &raquo;</a>{/if}&nbsp;
 					</div>
 				</div>


### PR DESCRIPTION
…omerid

Powód PR: ID zlewa się wizualnie z karma score.

PRZED:
![image](https://user-images.githubusercontent.com/17087236/167457642-bd77aac4-a99c-425e-9c05-5ab9cd598731.png)

PO:
![image](https://user-images.githubusercontent.com/17087236/167457553-c702620c-4756-4f10-898d-84117d04e590.png)