### PR TITLE
bugfix: not optional tarrifs - was marked as optional (approach #2 fo…

### DIFF
--- a/documents/templates/default/info.php
+++ b/documents/templates/default/info.php
@@ -35,6 +35,5 @@ $engine = array(
     'output' => 'default.html',         // output file name
     'plugin' => 'plugin',           // form plugin (in 'name' dir)
     'post-action' => 'post-action',     // action file executed after document addition (in transaction)
-    'promotion-schema-selection' => true, // show promotion schema selection
     'attachments' => array(),       // associative array with directly pointed optional attachment files (key = label; value = full path file name)
 );

--- a/documents/templates/default/info.php
+++ b/documents/templates/default/info.php
@@ -35,5 +35,6 @@ $engine = array(
     'output' => 'default.html',         // output file name
     'plugin' => 'plugin',           // form plugin (in 'name' dir)
     'post-action' => 'post-action',     // action file executed after document addition (in transaction)
+    'promotion-schema-selection' => true, // show promotion schema selection
     'attachments' => array(),       // associative array with directly pointed optional attachment files (key = label; value = full path file name)
 );

--- a/lib/locale/pl_PL/strings.php
+++ b/lib/locale/pl_PL/strings.php
@@ -33,6 +33,7 @@ $_LANG['Invoice value: $a (to pay)'] = 'Wartość faktury: $a (do zapłaty)';
 $_LANG['Invoice value: $a (to repay)'] = 'Wartość faktury: $a (do zwrotu)';
 
 $_LANG['Select tariff'] = 'Wybierz taryfę';
+$_LANG['— Select tariff —'] = '— Wybierz taryfę —';
 $_LANG['Document flags'] = 'Flagi dokumentu';
 $_LANG['The document is issued according to the $a price'] = 'Dokument wystawiony według ceny $a';
 $_LANG['calculated from net'] = 'liczone od netto';

--- a/modules/document.inc.php
+++ b/modules/document.inc.php
@@ -126,7 +126,11 @@ function GetPlugin($template, $customer, $update_title, $JSResponse)
         $JSResponse->assign('title', 'value', isset($engine['form_title']) ? $engine['form_title'] : $engine['title']);
     }
 
-    $JSResponse->script('$("#documentpromotions").toggle(' . (empty($engine['promotion-schema-selection']) ? 'false' : 'true') . ')');
+    $JSResponse->script(
+        empty($engine['promotion-schema-selection']) ?
+            "document.querySelectorAll('select.schema-tariff-selection').forEach(e => e.removeAttribute('required')); $('#documentpromotions').toggle(false);" :
+            "document.querySelectorAll('select.schema-tariff-selection').forEach(e => e.setAttribute('required', '')); $('#documentpromotions').toggle(true);"
+    );
 }
 
 function GetDocumentTemplates($rights, $type = null)

--- a/templates/default/customer/customerassignmenthelper.html
+++ b/templates/default/customer/customerassignmenthelper.html
@@ -308,7 +308,9 @@
 																<table>
 																	<tr class="schema-tariff-container-row">
 																		<td>
-																			<select class="schema-tariff-selection" name="{$variable_prefix}[sassignmentid][{$schemaid}][{$label}]" data-label="{$label}">
+																			<select class="schema-tariff-selection" name="{$variable_prefix}[sassignmentid][{$schemaid}][{$label}]"
+																			    data-label="{$label}" {if $item.selection.required}required{/if}>
+																				<option value="" hidden>{trans("— Select tariff —")}</option>
 																				{if !$item.selection.required}
 																				<option value="0" data-tariffaccess="-1" data-tarifftype="0">{trans("- none -")}</option>
 																				{/if}


### PR DESCRIPTION
…r PR#2267)

PR:
- oznaczanie opcji koniecznych do wyboru czerwoną ramką w "pomocniku" schematów promocji,
- zabranie opcji "-żaden-" w przypadku taryf "wymaganych",

Przed:
![Zrzut ekranu z 2023-11-21 15-37-46](https://github.com/chilek/lms/assets/17087236/d7badd93-87e2-4b53-9f97-8b175b2e8d44)

Po:
![image](https://github.com/chilek/lms/assets/17087236/7041b6c9-75c6-4666-be19-2e7c1e1e828e)

Taryfa opcjonalna:
![image](https://github.com/chilek/lms/assets/17087236/22ef363c-21fd-4548-b808-693a47256c27)

Taryfa bez flagi opcjonalna:
![image](https://github.com/chilek/lms/assets/17087236/56e3b5db-4180-4199-a8d4-dbc294ef2784)