### PR TITLE
bugfix: add missing id attribute for input filed when new mac is adde…

### DIFF
--- a/js/lms-ui-mac-address-selection.js
+++ b/js/lms-ui-mac-address-selection.js
@@ -28,7 +28,7 @@ $(function() {
 		$('table.lms-ui-mac-address-selection').append(
 			'<tr id="mac' + key + '" class="mac">' +
 			'<td style="width: 100%;">' +
-			'<input type="text" name="' + $(this).attr('data-field-prefix') + '[macs][' + key + ']" value="" ' +
+			'<input type="text" id="mac-input-' + key + '" name="' + $(this).attr('data-field-prefix') + '[macs][' + key + ']" value="" ' +
 			'placeholder="' + $t('MAC address') + '">' +
 			'&nbsp;<span class="ui-icon ui-icon-closethick remove-mac"></span>' +
 			'&nbsp;<a class="lms-ui-button mac-selector" ' +


### PR DESCRIPTION
…d to node

Jeśli dla pierwszego pola na adres mac podajemy atrybut id (https://github.com/chilek/lms-plus/blob/9d3476fbb03a766db9e405e94f4f9f0983b934b9/templates/default/node/nodeaddbox.html#L166) a zate m tutaj (https://github.com/chilek/lms-plus/blob/676e0581db5734dfc659f7c2d5bb5bfc6ce879c8/lib/SmartyPlugins/LMSSmartyPlugins.php#L785), to dla nowo dodawanych pól na adres mac też potrzeba to dodawać. Generalnie zmiana na potrzeby pluginu warehouse.