### PR TITLE
enhancement: require postcode (variable: phpui.zip_required, default:…

### DIFF
--- a/lib/SmartyPlugins/LMSSmartyPlugins.php
+++ b/lib/SmartyPlugins/LMSSmartyPlugins.php
@@ -479,6 +479,7 @@ class LMSSmartyPlugins
             $params = array();
         }
 
+        $zip_required = ConfigHelper::checkConfig('phpui.zip_required');
         // generate unique id for location box
         $LOCATION_ID = 'lmsui-' . uniqid();
 
@@ -620,7 +621,8 @@ class LMSSmartyPlugins
         echo '<tr>
               <td class="nobr">' . trans('Postcode') . '</td>
               <td>
-                <input type="text"   value="' . (!empty($params['location_zip']) ? $params['location_zip'] : '' ) . '" name="' . $input_name_zip . '" data-address="zip" size="7" maxlength="10">
+                <input type="text" value="' . (!empty($params['location_zip']) ? $params['location_zip'] : '' ) . '" name="' . $input_name_zip
+                    . '" data-address="zip" size="7" maxlength="10"' . ($zip_required ? ' required' : '') . '>
                 <a class="zip-code-button" href="#" title="' . trans('Click here to autocomplete zip code') . '">&raquo;&raquo;&raquo;</a>
               </td>
           </tr>';


### PR DESCRIPTION
… false)

Pomocna łatka na zapominalskich. Po akceptacji PR uzupełnię opis w wiki.

Gdy zmienna `phpui.zip_required` ma wartość `true` to pole kod pocztowy robi się czerwone i jest konieczne do uzupełnienia.

![image](https://github.com/chilek/lms/assets/17087236/ae82b57a-e3f0-41da-bf70-fa862b5f2112)

To jest ważne gdyż listy poczta polska cofa do nadawcy jeśli nie ma kodu a nazwa miejscowości nie jest jednokrotnie występująca w PL. Szczególnie przy edycji adresu była możliwość popełnienia zapominajki.