### PR TITLE
bugfix: rt.ticket_queue_change_resets_ticket_state didn't work as exp…

### DIFF
--- a/templates/default/rt/rtmessageadd.html
+++ b/templates/default/rt/rtmessageadd.html
@@ -4,9 +4,9 @@
 <!-- $Id$ -->
 {$xajax}
 
+{include file="rt/rtticketshared.html"}
+
 {$group_action=is_array($message.ticketid)}
-{$hide_disabled_users = ConfigHelper::checkConfig('rt.hide_disabled_users', ConfigHelper::checkConfig('phpui.helpdesk_hide_disabled_users'))}
-{$hide_deleted_users = ConfigHelper::checkConfig('rt.hide_deleted_users', ConfigHelper::checkConfig('phpui.helpdesk_hide_deleted_users'))}
 
 <style>
 
@@ -227,9 +227,8 @@
 			{/box_row}
 
 			{box_row icon="queue" icon_class="fa-fw" label="Queue"}
-				<select size="1" name="message[queueid]"
-					{tip text="Select queue" trigger="queue" class="lms-ui-advanced-select"}
-					onchange="xajax_queue_changed($(this).val(), $('#rtverifiers select').val())">
+				<select size="1" name="message[queueid]" id="queue-selection"
+					{tip text="Select queue" trigger="queue" class="lms-ui-advanced-select"}>
 					{if $group_action}
 						<option value="-100"{if $message.queueid == -100} selected{/if} data-newmessage-notify="1">{trans("— no changes —")}</option>
 					{/if}
@@ -242,7 +241,8 @@
 			{/box_row}
 
 			{box_row icon="owner" icon_class="fa-fw" label="Owner"}
-				<select size="1" name="message[owner]" {tip text="Select user" trigger="owner" class="lms-ui-advanced-select"}>
+				<select size="1" name="message[owner]" id="owner"
+					{tip text="Select user" trigger="owner" class="lms-ui-advanced-select"}>
 					<option value="0">{trans("— select user —")}</option>
 					{if $group_action}
 						<option value="-100"{if $message.owner == -100} selected{/if}>{trans("— no changes —")}</option>
@@ -370,37 +370,6 @@
 				$('#categories').hide();
 			}
 		}).change();
-
-		$('#resolve').change(function() {
-			var stateelem = $('#state');
-			if ($(this).prop('checked')) {
-				$(this).data('prev-state', stateelem.val());
-				stateelem.val({$smarty.const.RT_RESOLVED});
-			} else {
-				var prev_state = $(this).data('prev-state');
-				if (prev_state) {
-					stateelem.val(prev_state);
-				}
-			}
-		});
-
-		$('#state').change(function() {
-			$('#resolve').prop('checked', $(this).val() == {$smarty.const.RT_RESOLVED});
-		});
-
-		$('[name="message[owner]"]').change(function() {
-			$('#assign-to-me').prop('checked', false);
-		});
-
-		$('#assign-to-me').change(function() {
-			var select = $('[name="message[owner]"]');
-			if ($(this).prop('checked')) {
-				select.val($(this).attr('data-old-userid', select.val()).attr('data-userid'));
-			} else {
-				select.val($(this).attr('data-old-userid'));
-			}
-			updateAdvancedSelects(select);
-		});
 
 		$('body').on('change', '.template-selector', function() {
 			var selected = $('option:selected', this);

--- a/templates/default/rt/rtnoteadd.html
+++ b/templates/default/rt/rtnoteadd.html
@@ -2,9 +2,9 @@
 {block name=title}LMS: {$layout.pagetitle|striphtml}{/block}
 {block name=module_content}
 <!-- $Id$ -->
-{$hide_disabled_users = ConfigHelper::checkConfig('rt.hide_disabled_users', ConfigHelper::checkConfig('phpui.helpdesk_hide_disabled_users'))}
-{$hide_deleted_users = ConfigHelper::checkConfig('rt.hide_deleted_users', ConfigHelper::checkConfig('phpui.helpdesk_hide_deleted_users'))}
 {$xajax}
+{include file="rt/rtticketshared.html"}
+
 <h1>{$layout.pagetitle}</h1>
 <form method="POST" name="note" id="note-form" action="?m=rtnoteadd">
 	<input type="hidden" name="note[inreplyto]" value ="{$note.inreplyto|default:"0"}">
@@ -159,9 +159,8 @@
 				{trans("Queue")}
 			</td>
 			<td>
-				<select size="1" name="note[queueid]" form="note-form"
-					{tip text="Select queue" trigger="queue" class="lms-ui-advanced-select"}
-					onchange="xajax_queue_changed($(this).val(), $('#rtverifiers select').val())">
+				<select size="1" name="note[queueid]" form="note-form" id="queue-selection"
+					{tip text="Select queue" trigger="queue" class="lms-ui-advanced-select"}>
 					{foreach $queuelist as $item}
 					<option value="{$item.id}"
 						{if $item.id == $note.queueid} selected{/if}>{$item.name}</option>
@@ -175,7 +174,7 @@
 				{trans("Owner")}
 			</td>
 			<td>
-				<select size="1" name="note[owner]" form="note-form"
+				<select size="1" name="note[owner]" form="note-form" id="owner"
 					{tip text="Select user" trigger="owner" class="lms-ui-advanced-select"}>
 					<option value="0">{trans("— select user —")}</option>
 					{foreach $userlist as $user}
@@ -278,7 +277,7 @@
 
 {include file="rt/rtticketmessagesbox.html"}
 
-<SCRIPT>
+<script>
 
 	$(function() {
 		$('[name="note[body]"]').focus();
@@ -291,37 +290,6 @@
 			}
 		}).change();
 
-		$('#resolve').change(function() {
-			var stateelem = $('#state');
-			if ($(this).prop('checked')) {
-				$(this).data('prev-state', stateelem.val());
-				stateelem.val({$smarty.const.RT_RESOLVED});
-			} else {
-				var prev_state = $(this).data('prev-state');
-				if (prev_state) {
-					stateelem.val(prev_state);
-				}
-			}
-		});
-
-		$('#state').change(function() {
-			$('#resolve').prop('checked', $(this).val() == {$smarty.const.RT_RESOLVED});
-		});
-
-		$('[name="note[owner]"]').change(function() {
-			$('#assign-to-me').prop('checked', false);
-		});
-
-		$('#assign-to-me').change(function() {
-			var select = $('[name="note[owner]"]');
-			if ($(this).prop('checked')) {
-				select.val($(this).attr('data-old-userid', select.val()).attr('data-userid'));
-			} else {
-				select.val($(this).attr('data-old-userid'));
-			}
-			updateAdvancedSelects(select);
-		});
-
 		$('body').on('change', '.template-selector', function() {
 			var selected = $('option:selected', this);
 			if (parseInt(selected.val()) == 0) {
@@ -331,5 +299,6 @@
 		});
 	});
 
-</SCRIPT>
+</script>
+
 {/block}

--- a/templates/default/rt/rtticketmodify.html
+++ b/templates/default/rt/rtticketmodify.html
@@ -1,5 +1,4 @@
-{$hide_disabled_users = ConfigHelper::checkConfig('rt.hide_disabled_users', ConfigHelper::checkConfig('phpui.helpdesk_hide_disabled_users'))}
-{$hide_deleted_users = ConfigHelper::checkConfig('rt.hide_deleted_users', ConfigHelper::checkConfig('phpui.helpdesk_hide_deleted_users'))}
+{include file="rt/rtticketshared.html"}
 
 <style>
 
@@ -170,7 +169,8 @@
 		{box_panel}
 			{block name="rtticketmodify-rightcolumn"}
 			{box_row icon="owner" label="Owner" icon_class="fa-fw"}
-				<select size="1" name="ticket[owner]" {tip class="lms-ui-advanced-select" text="Select user" trigger="owner"}>
+				<select size="1" name="ticket[owner]" id="owner"
+						{tip class="lms-ui-advanced-select" text="Select user" trigger="owner"}>
 					<option value="0">{trans("— select user —")}</option>
 					{foreach $userlist as $user}
 						{if $user.id != $ticket.owner
@@ -245,9 +245,8 @@
 			{/box_row}
 
 			{box_row icon="queue" label="Queue" icon_class="fa-fw"}
-				<select size="1" name="ticket[queue]"
-						{tip class="lms-ui-advanced-select" text="Select queue" trigger="queue"}
-						onchange="xajax_queue_changed($(this).val(), $('#rtverifiers select').val())">
+				<select size="1" name="ticket[queue]" id="queue-selection"
+						{tip class="lms-ui-advanced-select" text="Select queue" trigger="queue"}>
 					{foreach $queuelist as $item}
 						<option value="{$item.id}"
 							{if $item.newticketsubject && $item.newticketbody || $item.newticketsmsbody} data-newticket-notify="1"{/if}
@@ -388,21 +387,36 @@
 
 <script src="js/templates/rt/rtticketmodify.js"></script>
 <script>
-
-	$(function() {
-		$('#resolve').change(function() {
-			var stateelem = $('#state');
-			if ($(this).prop('checked')) {
-				$(this).data('prev-state', stateelem.val());
-				stateelem.val({$smarty.const.RT_RESOLVED});
+		$("#resolve").change(function() {
+			var stateelem = $("#state");
+			var ownerelem = $("#owner");
+			if ($(this).prop("checked")) {
+				stateelem.attr("prev-state", stateelem.val()).val({$smarty.const.RT_RESOLVED});
+				ownerelem.attr("prev-state", ownerelem.val()).val({$layout.logid});
 			} else {
-				var prev_state = $(this).data('prev-state');
-				if (prev_state) {
-					stateelem.val(prev_state);
+				var state_prev_state = stateelem.attr("prev-state");
+				if (state_prev_state) {
+					stateelem.val(state_prev_state);
+				}
+				var owner_prev_state = ownerelem.attr("prev-state");
+				if (owner_prev_state) {
+					ownerelem.val(owner_prev_state);
 				}
 			}
 			updateAdvancedSelects(stateelem);
+			updateAdvancedSelects(ownerelem);
 		});
+
+		$( "#queue-selection" ).change(
+			function() {
+				{if !empty($reset_ticket_state)}
+					$("#state option:eq({$_RT_NEW})").prop("selected", true);
+					updateAdvancedSelects(state);
+					$("#resolve").prop("checked", false);
+				{/if}
+				xajax_queue_changed($(this).val(), $("#rtverifiers select").val());
+			}
+		);
 
 		$('#state').change(function() {
 			$('#resolve').prop('checked', $(this).val() == {$smarty.const.RT_RESOLVED});
@@ -445,6 +459,5 @@
 			excluded_elements: [ {if isset($ticket.ticketid)}'{$ticket.ticketid}'{/if} ],
 			conflict_lists: [ '#parent-ticket' ]
 		});
-	});
 
 </script>

--- a/templates/default/rt/rtticketshared.html
+++ b/templates/default/rt/rtticketshared.html
@@ -1,0 +1,60 @@
+{$hide_disabled_users = ConfigHelper::checkConfig('rt.hide_disabled_users', ConfigHelper::checkConfig('phpui.helpdesk_hide_disabled_users'))}
+{$hide_deleted_users = ConfigHelper::checkConfig('rt.hide_deleted_users', ConfigHelper::checkConfig('phpui.helpdesk_hide_deleted_users'))}
+{$reset_ticket_state = ConfigHelper::checkConfig('rt.ticket_queue_change_resets_ticket_state')}
+
+<script>
+
+$(function() {
+	$("#resolve").change(function() {
+                var stateelem = $("#state");
+                var ownerelem = $("#owner");
+                if ($(this).prop("checked")) {
+                        stateelem.attr("prev-state", stateelem.val()).val({$smarty.const.RT_RESOLVED});
+                        ownerelem.attr("prev-state", ownerelem.val()).val({$layout.logid});
+                } else {
+                        var state_prev_state = stateelem.attr("prev-state");
+                        if (state_prev_state) {
+                                stateelem.val(state_prev_state);
+                        }
+                        var owner_prev_state = ownerelem.attr("prev-state");
+                        if (owner_prev_state) {
+                                ownerelem.val(owner_prev_state);
+                        }
+                }
+                updateAdvancedSelects(stateelem);
+                updateAdvancedSelects(ownerelem);
+        });
+
+        $("#queue-selection").change(function() {
+                {if !empty($reset_ticket_state)}
+                        $('#state option:eq("{$smarty.const.RT_NEW}")').prop("selected", true);
+                        updateAdvancedSelects(state);
+                        $("#resolve").prop("checked", false);
+                {/if}
+                xajax_queue_changed($(this).val(), $("#rtverifiers select").val());
+        });
+
+        $("#state").change(function() {
+                $('#resolve').prop('checked', $(this).val() == {$smarty.const.RT_RESOLVED});
+        });
+
+        $("#owner").change(function() {
+                if ($(this).val == {$layout.logid}) {
+	                $('#assign-to-me').prop('checked', false);
+                } else {
+                        $('#assign-to-me').prop('checked', true);
+                }
+        });
+
+        $("#assign-to-me").change(function() {
+                var select = $('#owner');
+                if ($(this).prop('checked')) {
+                        select.val($(this).attr('data-old-userid', select.val()).attr('data-userid'));
+                } else {
+                        select.val($(this).attr('data-old-userid'));
+                }
+		updateAdvancedSelects(select);
+        });
+});
+
+</script>


### PR DESCRIPTION
…ected when there was no owner set

PR naprawia oczekiwane zachowanie zmianę stanu kolejki na nowy przy zmianie kolejki (sterowanie zmienną rt.ticket_queue_change_resets_ticket_state)

Przy okazji uwspólniania kodu i testowania wyszło, że część funkcji JS w rtnoteadd nie działa a część nie działa w rtmessageadd ;-)
Dlatego sugeruję tą zmianę nanieść na stable.