### PR TITLE
bugfix: proper buttons visibility in ticket view

### DIFF
--- a/templates/default/rt/rtticketinfobox.html
+++ b/templates/default/rt/rtticketinfobox.html
@@ -380,10 +380,10 @@
 				{/if}
 			{/if}
 			{buttons type="button" icon="dropdown2" label="Additional options"}
-				{if ($ticket.owner != $layout.logid && $ticket.state != $smarty.const.RT_RESOLVED) || ConfigHelper::checkPrivilege('superuser')}
+				{if ($ticket.owner != $layout.logid && $ticket.state != $smarty.const.RT_RESOLVED)}
 					{button id="ticket-assign-to-me" icon="user" label="Assign to me" tip="Assign to me" data_href="?m=rtticketedit&id={$ticket.ticketid}&action=assign"}
 				{/if}
-				{if (!$ticket.verifier && $ticket.owner != $layout.logid && $ticket.state != $smarty.const.RT_RESOLVED) || ConfigHelper::checkPrivilege('superuser')}
+				{if (!$ticket.verifierid && $ticket.owner != $layout.logid && $ticket.state != $smarty.const.RT_RESOLVED)}
 					{button id="ticket-assign2-to-me" type='link-button' icon="user" label="Assign to me as verifier" tip="Assign to me as verifier" href="?m=rtticketedit&id={$ticket.ticketid}&action=assign2"}
 				{/if}
 				{if $ticket.watching}


### PR DESCRIPTION
PR:
naprawia widoczność przycisków dla użytkowników z uprawnieniem "pełne uprawnienia" w formularzu rtticketinfobox.html 

Nie ma sensu pokazywać dla superusera przycisków:
- "przypisz jako weryfikator" gdy superuser już nim jest,
- "przypisz do mnie" dla zamkniętych ticketów,

Przed:
![image](https://github.com/chilek/lms/assets/17087236/ac8ab6b5-fb26-43f8-ab5d-507f7373dfae)

Po:
![image](https://github.com/chilek/lms/assets/17087236/e89414c5-15ee-4185-8201-8b7d58a6c9e1)