### PR TITLE
bugfix: missing dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,6 +115,7 @@
         "ext-gmp": "*",
         "ext-curl": "*",
         "ext-intl": "*",
+        "ext-ctype": "*",
         "phine/observer": "2.0",
         "phine/exception": "1.0",
         "phpmailer/phpmailer": "^6",


### PR DESCRIPTION
PR dodaje brakującą zależność modułu ctype w PHP - w wielu dystrybucjach jest on domyślnie włączony.