### PR TITLE
bugfix: button is not disabled when rt.block_ticket_close_with_open_e…

### DIFF
--- a/templates/default/rt/rtqueueviewboxrow.html
+++ b/templates/default/rt/rtqueueviewboxrow.html
@@ -130,8 +130,8 @@
 				{if $ticket.verifierid && $ticket.verifierid != Auth::GetCurrentUser() &&  $ticket.state != $smarty.const.RT_VERIFIED}
 					{button type="link" icon="verifier" tip="Transfer to verifier" href="?m=rtticketedit&id={$ticket.id}&action=verify"}
 				{elseif ConfigHelper::checkConfig('rt.block_ticket_close_with_open_events', ConfigHelper::checkConfig('phpui.helpdesk_block_ticket_close_with_open_events'))
-					&& $ticket['openeventcount'] !== 0}
-					{button type="link" icon="close" tip="Resolve" href="?m=rtticketedit&id={$ticket.id}&action=resolve" class="disabled" tip="Ticket have open assigned events!"}
+					&& !empty(ticket.eventcountopened)}
+					{button type="link" icon="close" tip="Resolve" href="?m=rtticketedit&id={$ticket.id}&action=resolve" disabled=true tip="Ticket have open assigned events!"}
 				{else}
 					{button type="link" icon="close" tip="Resolve" href="?m=rtticketedit&id={$ticket.id}&action=resolve"}
 				{/if}


### PR DESCRIPTION
…vents=true and ticket has opened events

PR naprawia wyłączanie przycisku "Rozwiąż" w przypadku gdy zmienna **rt.block_ticket_close_with_open_events=true** i ticket posiada przypisane otwarte zdarzenia.