### PR TITLE
bugfix: uibug: don't allow to break label/select pair

### DIFF
--- a/templates/default/netdev/netdevlist.html
+++ b/templates/default/netdev/netdevlist.html
@@ -47,50 +47,57 @@
 	</TR>
 	<TR>
 		<TD colspan="6">
-			{trans("Status")}:
-			<SELECT SIZE="1" NAME="s" ONCHANGE="document.choosefilter.submit();">
-				<OPTION VALUE="-1" {if $listdata.status == -1}  SELECTED {/if}>{trans("— all —")}</OPTION>
-				{foreach $_NETELEMENTSTATUSES as $idx => $status}
-					<OPTION VALUE="{$idx}"{if $listdata.status == $idx} SELECTED{/if}>{$status}</OPTION>
-				{/foreach}
-				<OPTION value="100"{if $listdata.status == 100} selected{/if}>{trans("TERYT not specified")}</OPTION>
-				<OPTION value="101"{if $listdata.status == 101} selected{/if}>{trans("online")}</OPTION>
-				<option value="102"{if $listdata.status == 102} selected{/if}>{trans("no connections")}</option>
-			</SELECT>
-			{trans("Project:")}
-			<SELECT SIZE="1" NAME="p" ONCHANGE="document.choosefilter.submit();">
-				<OPTION VALUE="-1"{if $listdata.invprojectid == -1} selected{/if}>{trans("— all —")}</OPTION>
-				<OPTION VALUE="-2"{if $listdata.invprojectid == -2} selected{/if}>— {trans("without project")} —</OPTION>
-				{foreach $NNprojects as $project}
-					<OPTION value="{$project.id}"{if ($listdata.invprojectid == $project.id)} selected{/if}>{$project.name|escape}</OPTION>
-				{/foreach}
-			</SELECT>
-			{trans("Network node:")}
-			<SELECT NAME="n" ONCHANGE="document.choosefilter.submit();" {tip class="lms-ui-advanced-select" text="Select network node (optional)" trigger="netnodeid"}>
-				<OPTION VALUE="-1"{if $listdata.netnode == -1} selected{/if}>{trans("— all —")}</OPTION>
-				<OPTION VALUE="-2"{if $listdata.netnode == -2} selected{/if}>{trans("— none —")}</OPTION>
-				{foreach $netnodes as $netnode}
-				<OPTION VALUE="{$netnode.id}"{if $listdata.netnode == $netnode.id} selected{/if}>{$netnode.name}</OPTION>
-				{/foreach}
-			</SELECT>
-			{trans("Type")}
-			{networkDeviceTypes elemname="type" selected=$listdata.type onchange="document.choosefilter.submit();"}
-			{trans("Producer:")}
-			<SELECT SIZE="1" NAME="producer" ONCHANGE="document.choosefilter.submit();">
-				<OPTION VALUE="-1"{if $listdata.producer == -1} selected{/if}>{trans("— all —")}</OPTION>
-				<OPTION VALUE="-2"{if $listdata.producer == -2} selected{/if}>{trans("— none —")}</OPTION>
-				{foreach $producers as $producer}
-				<OPTION VALUE="{$producer}"{if $listdata.producer == $producer} selected{/if}>{$producer}</OPTION>
-				{/foreach}
-			</SELECT>
-			{trans("Model:")}
-			<SELECT SIZE="1" NAME="model" ONCHANGE="document.choosefilter.submit();">
-				<OPTION VALUE="-1"{if $listdata.model == -1} selected{/if}>{trans("— all —")}</OPTION>
-				<OPTION VALUE="-2"{if $listdata.model == -2} selected{/if}>{trans("— none —")}</OPTION>
-				{foreach $models as $model}
-				<OPTION VALUE="{$model}"{if $listdata.model == $model} selected{/if}>{$model}</OPTION>
-				{/foreach}
-			</SELECT>
+			<span class="nobr">{trans("Status")}:
+				<select size="1" name="s" onchange="document.choosefilter.submit();">
+					<option value="-1" {if $listdata.status == -1} selected{/if}>{trans("— all —")}</option>
+					{foreach $_NETELEMENTSTATUSES as $idx => $status}
+						<option value="{$idx}"{if $listdata.status == $idx} selected{/if}>{$status}</option>
+					{/foreach}
+					<option value="100"{if $listdata.status == 100} selected{/if}>{trans("TERYT not specified")}</option>
+					<option value="101"{if $listdata.status == 101} selected{/if}>{trans("online")}</option>
+					<option value="102"{if $listdata.status == 102} selected{/if}>{trans("no connections")}</option>
+				</select>
+			</span>
+			<span class="nobr">{trans("Project:")}
+				<select size="1" name="p" onchange="document.choosefilter.submit();">
+					<option value="-1"{if $listdata.invprojectid == -1} selected{/if}>{trans("— all —")}</option>
+					<option value="-2"{if $listdata.invprojectid == -2} selected{/if}>{trans("— without project —")}</option>
+					{foreach $NNprojects as $project}
+						<option value="{$project.id}"{if ($listdata.invprojectid == $project.id)} selected{/if}>{$project.name|escape}</option>
+					{/foreach}
+				</select>
+			</span>
+			<span class="nobr">{trans("Network node:")}
+				<select name="n" onchange="document.choosefilter.submit();"
+						{tip class="lms-ui-advanced-select" text="Select network node (optional)" trigger="netnodeid"}>
+					<option value="-1"{if $listdata.netnode == -1} selected{/if}>{trans("— all —")}</option>
+					<option value="-2"{if $listdata.netnode == -2} selected{/if}>{trans("— none —")}</option>
+					{foreach $netnodes as $netnode}
+					<option value="{$netnode.id}"{if $listdata.netnode == $netnode.id} selected{/if}>{$netnode.name}</option>
+					{/foreach}
+				</select>
+			</span>
+			<span class="nobr">{trans("Type")}
+				{networkDeviceTypes elemname="type" selected=$listdata.type onchange="document.choosefilter.submit();"}
+			</span>
+			<span class="nobr">{trans("Producer:")}
+				<select size="1" name="producer" onchange="document.choosefilter.submit();">
+					<option value="-1"{if $listdata.producer == -1} selected{/if}>{trans("— all —")}</option>
+					<option value="-2"{if $listdata.producer == -2} selected{/if}>{trans("— none —")}</option>
+					{foreach $producers as $producer}
+					<option value="{$producer}"{if $listdata.producer == $producer} selected{/if}>{$producer}</option>
+					{/foreach}
+				</select>
+			</span>
+			<span class="nobr">{trans("Model:")}
+				<select size="1" name="model" onchange="document.choosefilter.submit();">
+					<option value="-1"{if $listdata.model == -1} selected{/if}>{trans("— all —")}</option>
+					<option value="-2"{if $listdata.model == -2} selected{/if}>{trans("— none —")}</option>
+					{foreach $models as $model}
+					<option value="{$model}"{if $listdata.model == $model} selected{/if}>{$model}</option>
+					{/foreach}
+				</select>
+			</span>
 		</TD>
 	</TR>
 	{if $pagination->getTotal() != 0}


### PR DESCRIPTION
PR zawiera:
1. Opakowanie elementów każdego filtra w `<span class="nobr">`.
2. Zmieniona wielkość znaczników HTML i ich atrbutów 
(bo i tak musiałem zedytować te linie, żeby zrobić prawidłowe wcięcia w kodzie)

PR rozwiązuje problem dzielenia elementów pojedyńczego filtra (etykietki+elementu select) na dwie linie przy różnych wielkościach viewportu przeglądarki. Strasznie to wkurzało.