### PR TITLE
bugfix: repair support allow_modify_values_for_privileged_user for su…

### DIFF
--- a/lib/LMSManagers/LMSFinanceManager.php
+++ b/lib/LMSManagers/LMSFinanceManager.php
@@ -4903,7 +4903,7 @@ class LMSFinanceManager extends LMSManager implements LMSFinanceManagerInterface
             }
         }
 
-        return $promotions;
+        return $promotion_schema_item;
     }
 
     public function AggregateDocuments($list)


### PR DESCRIPTION
…peruser or users with promotion_management privilege

Wg przyjętych założeń: użytkownicy z pełnymi prawami (superuser) oraz Ci, którzy posiadają uprawnienie promotion_management przy włączonej zmiennej **promotions.allow_modify_values_for_privileged_user** powinni mieć możliwość zmiany wszystkich cen przy generowaniu umowy (niezależnie od przyznanych uprawnień w edycji schematu).