### PR TITLE
bugfix: escape in smarty template is not needed as we used htmlspecia…

### DIFF
--- a/templates/default/customer/customerassignmenthelper.html
+++ b/templates/default/customer/customerassignmenthelper.html
@@ -550,7 +550,7 @@
                                                                 <TD>{icon name="notes"}</TD>
                                                                 <TD class="bold nobr">{trans("Note")}</TD>
                                                                 <TD>
-                                                                        <INPUT type="text" name="{$variable_prefix}[note]" value="{if $variables.note}{$variables.note|escape}{/if}" size="30" {tip text="Enter assignment/liability note" trigger="note"}>
+                                                                        <INPUT type="text" name="{$variable_prefix}[note]" value="{if $variables.note}{$variables.note}{/if}" size="30" {tip text="Enter assignment/liability note" trigger="note"}>
                                                                 </TD>
                                                         </TR>
 


### PR DESCRIPTION
…lchars() in backend