### PR TITLE
bugfix: proper redirect after deleting events from rtticketview event…

### DIFF
--- a/modules/eventdel.php
+++ b/modules/eventdel.php
@@ -24,7 +24,7 @@
  *  $Id$
  */
 
-$id = $_GET['id'];
+$id = intval($_GET['id']);
 
 if ($id) {
     $LMS->executeHook(
@@ -36,18 +36,6 @@ if ($id) {
     $LMS->EventDelete($id);
 }
 
-
 $backto = $SESSION->remove_history_entry();
-
-if (!empty($backto)) {
-    if (strpos($backto, 'm=rtticketview') !== false) {
-        $SESSION->redirect($backto);
-    } elseif (strpos($backto, 'm=eventinfo') !== false) {
-        $SESSION->redirect('?m=eventlist');
-    } else {
-        $SESSION->redirect('?' . $backto);
-    }
-}
-
 $backid = $SESSION->get('backid');
-$SESSION->redirect($backto . (empty($backid) ? '' : '#' . $backid));
+$SESSION->redirect('?' . $backto . (empty($backid) ? '' : '#' . $backid));


### PR DESCRIPTION
…s panel

Przetestowałem przekierowania po usunięciu zdarzenia z miejsc:
- karta klienta panel Terminarz Klienta (customerevents),
- terminarz (eventlist),
- widok karty zdarzenia (eventinfo),
- widok zgłoszenia panel "Przypisane zdarzenia w terminarzu" (rtticketeventlist),