### PR TITLE
improvement: control settlement setting in UI when assigment period i…

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1080,3 +1080,16 @@ function financeRound(value, precision) {
 	roundedValue = roundedValue.toFixed(precision).replace(/[\.]+/, ',');
 	return roundedValue;
 }
+
+// dedicated to some data checks
+let checkDate = {
+	ifFirstDayOfMonth: function(date){
+		let day = new Date(date).getDate();
+		return (day === 1);
+	},
+	ifLastDayOfMonth: function(date) {
+		let day = new Date(date).getDate();
+		let lastDayOfMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+		return (lastDayOfMonth === day);
+	}
+};

--- a/js/customerassignmenthelper.js
+++ b/js/customerassignmenthelper.js
@@ -600,6 +600,9 @@ $('#assignment-period').change(function() {
 	$('#last-day-of-month').closest('label').toggle($(this).val() == lmsSettings.monthlyPeriod);
 });
 
+const settlementElem = $('#a_settlement');
+const lastSettlementElem = $('#last-settlement');
+
 function tariffSelectionHandler() {
 	var promotion_select = parseInt($('#promotion-select').val());
 	var tariff_select = $('#tariff-select');
@@ -627,6 +630,28 @@ function tariffSelectionHandler() {
 
 	$('#last-settlement').prop('disabled', $('#align-periods').prop('checked') && val == -2)
 		.closest('label').toggleClass('lms-ui-disabled', $('#align-periods').prop('checked') && val == -2);
+
+	let dateFrom = $('#a_datefrom').datepicker( "getDate" );
+	if (dateFrom == null || (dateFrom != null && checkDate.ifFirstDayOfMonth(dateFrom))) {
+		if (settlementElem.is('input')) {
+			settlementElem.prop({checked: false, disabled: true});
+		} else {
+			settlementElem.val(0).prop('disabled', true);
+		}
+	} else {
+		if (settlementElem.is('input')) {
+			settlementElem.prop({checked: false, disabled: false});
+		} else {
+			settlementElem.val(0).prop('disabled', false);
+		}
+	}
+
+	let dateTo = $('#a_dateto').datepicker( "getDate" );
+	if (dateTo == null || (dateTo != null && checkDate.ifLastDayOfMonth(dateTo))) {
+		lastSettlementElem.prop({checked: false, disabled: true});
+	} else {
+		lastSettlementElem.prop({checked: false, disabled: false});
+	}
 
 	$('#netflag, #tax, #taxcategory, #splitpayment').prop('disabled', false);
 	$('#a_tax, #a_taxcategory, #a_splitpayment').removeClass('lms-ui-disabled');
@@ -988,3 +1013,29 @@ $('#align-periods').change(function() {
 		"checked": $(this).prop('checked') ? false : $('#last-settlement').prop('checked')
 	}).closest('label').toggleClass('lms-ui-disabled', $(this).prop('checked'));
 }).change();
+
+$('#a_datefrom').on('change', function () {
+	let dateFrom = $('#a_datefrom').datepicker( "getDate" );
+	if (dateFrom == null || (dateFrom != null && checkDate.ifFirstDayOfMonth(dateFrom))) {
+		if (settlementElem.is('input')) {
+			settlementElem.prop({checked: false, disabled: true});
+		} else {
+			settlementElem.val(0).prop('disabled', true);
+		}
+	} else {
+		if (settlementElem.is('input')) {
+			settlementElem.prop({checked: false, disabled: false});
+		} else {
+			settlementElem.val(0).prop('disabled', false);
+		}
+	}
+});
+
+$('#a_dateto').on('change', function () {
+	let dateTo = $('#a_dateto').datepicker( "getDate" );
+	if (dateTo == null || (dateTo != null && checkDate.ifLastDayOfMonth(dateTo))) {
+		lastSettlementElem.prop({checked: false, disabled: true});
+	} else {
+		lastSettlementElem.prop({checked: false, disabled: false});
+	}
+});

--- a/js/customerassignmenthelper.js
+++ b/js/customerassignmenthelper.js
@@ -600,7 +600,7 @@ $('#assignment-period').change(function() {
 	$('#last-day-of-month').closest('label').toggle($(this).val() == lmsSettings.monthlyPeriod);
 });
 
-const settlementElem = $('#a_settlement');
+const firstSettlementElem = $('#first-settlement');
 const lastSettlementElem = $('#last-settlement');
 
 function tariffSelectionHandler() {
@@ -633,16 +633,16 @@ function tariffSelectionHandler() {
 
 	let dateFrom = $('#a_datefrom').datepicker( "getDate" );
 	if (dateFrom == null || (dateFrom != null && checkDate.ifFirstDayOfMonth(dateFrom))) {
-		if (settlementElem.is('input')) {
-			settlementElem.prop({checked: false, disabled: true});
+		if (firstSettlementElem.is('input')) {
+			firstSettlementElem.prop({checked: false, disabled: true});
 		} else {
-			settlementElem.val(0).prop('disabled', true);
+			firstSettlementElem.val(0).prop('disabled', true);
 		}
 	} else {
-		if (settlementElem.is('input')) {
-			settlementElem.prop({checked: false, disabled: false});
+		if (firstSettlementElem.is('input')) {
+			firstSettlementElem.prop({checked: false, disabled: false});
 		} else {
-			settlementElem.val(0).prop('disabled', false);
+			firstSettlementElem.val(0).prop('disabled', false);
 		}
 	}
 
@@ -1017,16 +1017,16 @@ $('#align-periods').change(function() {
 $('#a_datefrom').on('change', function () {
 	let dateFrom = $('#a_datefrom').datepicker( "getDate" );
 	if (dateFrom == null || (dateFrom != null && checkDate.ifFirstDayOfMonth(dateFrom))) {
-		if (settlementElem.is('input')) {
-			settlementElem.prop({checked: false, disabled: true});
+		if (firstSettlementElem.is('input')) {
+			firstSettlementElem.prop({checked: false, disabled: true});
 		} else {
-			settlementElem.val(0).prop('disabled', true);
+			firstSettlementElem.val(0).prop('disabled', true);
 		}
 	} else {
-		if (settlementElem.is('input')) {
-			settlementElem.prop({checked: false, disabled: false});
+		if (firstSettlementElem.is('input')) {
+			firstSettlementElem.prop({checked: false, disabled: false});
 		} else {
-			settlementElem.val(0).prop('disabled', false);
+			firstSettlementElem.val(0).prop('disabled', false);
 		}
 	}
 });

--- a/templates/default/customer/customerassignmenthelper.html
+++ b/templates/default/customer/customerassignmenthelper.html
@@ -598,13 +598,13 @@
 								</TD>
 								<TD>
 									{trans("from:")}
-									<input type="text" name="{$variable_prefix}[datefrom]"
+									<input type="text" id="a_datefrom" name="{$variable_prefix}[datefrom]"
 										value="{if $variables.datefrom}{$variables.datefrom}{/if}"
 										placeholder="{trans("yyyy/mm/dd")}"
 										{tip class="lms-ui-date lms-ui-date-unix" text="Enter accounting start date in YYYY/MM/DD format. If you don't want to define 'From' date leave this field empty" trigger="datefrom"}
 										size="10">
 									{trans("to:")}
-									<input type="text" name="{$variable_prefix}[dateto]"
+									<input type="text" id="a_dateto" name="{$variable_prefix}[dateto]"
 										value="{if $variables.dateto}{$variables.dateto}{/if}"
 										placeholder="{trans("yyyy/mm/dd")}"
 										{tip class="lms-ui-date lms-ui-date-unix" text="Enter accounting end date in YYYY/MM/DD format. Leave this field empty if you don't want to set expiration date" trigger="dateto"}
@@ -878,11 +878,11 @@
 						<br>
 						<label>
 							{if $variables.id}
-							<INPUT type="checkbox" name="{$variable_prefix}[settlement]" value="1"{if $variables.settlement} checked{/if}>
+							<INPUT type="checkbox" id="a_settlement" name="{$variable_prefix}[settlement]" value="1"{if $variables.settlement} checked{/if}>
 							{trans("with settlement of first deficient period")}
 							{else}
 							{trans("settlement type of first deficient period:")}
-							<SELECT name="{$variable_prefix}[settlement]">
+							<SELECT id="a_settlement" name="{$variable_prefix}[settlement]">
 								<OPTION value="0">{trans("<!settlement>— none —")}</OPTION>
 								<OPTION value="1"{if $variables.settlement == 1} selected{/if}>{trans("<!settlement>next period")}</OPTION>
 								<OPTION value="2"{if $variables.settlement == 2} selected{/if}>{trans("<!settlement>current period")}</OPTION>

--- a/templates/default/customer/customerassignmenthelper.html
+++ b/templates/default/customer/customerassignmenthelper.html
@@ -878,11 +878,11 @@
 						<br>
 						<label>
 							{if $variables.id}
-							<INPUT type="checkbox" id="a_settlement" name="{$variable_prefix}[settlement]" value="1"{if $variables.settlement} checked{/if}>
+							<INPUT type="checkbox" id="first-settlement" name="{$variable_prefix}[settlement]" value="1"{if $variables.settlement} checked{/if}>
 							{trans("with settlement of first deficient period")}
 							{else}
 							{trans("settlement type of first deficient period:")}
-							<SELECT id="a_settlement" name="{$variable_prefix}[settlement]">
+							<SELECT id="first-settlement" name="{$variable_prefix}[settlement]">
 								<OPTION value="0">{trans("<!settlement>— none —")}</OPTION>
 								<OPTION value="1"{if $variables.settlement == 1} selected{/if}>{trans("<!settlement>next period")}</OPTION>
 								<OPTION value="2"{if $variables.settlement == 2} selected{/if}>{trans("<!settlement>current period")}</OPTION>


### PR DESCRIPTION
…s full months

![image](https://github.com/chilek/lms/assets/7595420/75deb43a-baea-4c3f-8be7-9e079a9a94dd)

Przed zmianą:
W momencie dodawania zobowiązania i podaniu 'Okresu' zawierającego się w pełnych miesiącach można też zaznaczyć wyrównanie początkowego i końcowego okresu niepełnego.  Prowadzi to do utworzenia zobowiązania z wyrównaniem, chociaż całe zobowiązanie zawiera się w pełnych miesiącach.

Po zmianie:
Jeśli pole 'Okres' zawiera się w pełnych miesiącach, lub jest puste, ustawianie wyrównania początkowego i końcowego okresu są niedostępne.
  