### PR TITLE
bugfix: remove quotation in mail header "from", it look badly in some email clients like thunderbird

### DIFF
--- a/lib/LMSManagers/LMSDocumentManager.php
+++ b/lib/LMSManagers/LMSDocumentManager.php
@@ -2713,8 +2713,6 @@ class LMSDocumentManager extends LMSManager implements LMSDocumentManagerInterfa
                 $subject
             );
 
-            $doc['name'] = '"' . $doc['name'] . '"';
-
             $mailto = array();
             $mailto_qp_encoded = array();
             foreach (explode(',', $custemail) as $email) {


### PR DESCRIPTION
Wysyłając fakturę w kliencie poczty widać niepotrzebny cudzysłów (metoda SendInvoices). 
Wysyłając wygenerowany dokument nie ma tego efektu (metoda DocumentsSend).
Jest bardzo dużo kodu wspólnego między tymi metodami.