### PR TITLE
improvement: make userlist more unificated/compact by cumulating users into {user_list_compact}

### DIFF
--- a/lib/LMSManagers/LMSEventManager.php
+++ b/lib/LMSManagers/LMSEventManager.php
@@ -329,7 +329,7 @@ class LMSEventManager extends LMSManager implements LMSEventManagerInterface
         $event['helpdesk'] = !empty($event['ticketid']);
 
         $event['userlist'] = $this->db->GetAllByKey(
-            'SELECT u.id, u.rname, u.name, u.login
+            'SELECT u.id, u.rname, u.name, u.login, u.deleted, u.access
             FROM vusers u
             JOIN eventassignments a ON a.userid = u.id
             WHERE a.eventid = ?',
@@ -605,11 +605,12 @@ class LMSEventManager extends LMSManager implements LMSEventManagerInterface
                     $row['nodelocation'] = $customerstuffaddresses[$row['customerid']];
                 }
 
-                $row['userlist'] = $this->db->GetAll(
+                $row['userlist'] = $this->db->GetAllByKey(
                     'SELECT userid AS id, vusers.name,
                     vusers.access, vusers.deleted, vusers.accessfrom, vusers.accessto
                     FROM eventassignments, vusers
                     WHERE userid = vusers.id AND eventid = ? ',
+                    'id',
                     array($row['id'])
                 );
 

--- a/lib/LMSManagers/LMSHelpdeskManager.php
+++ b/lib/LMSManagers/LMSHelpdeskManager.php
@@ -956,24 +956,42 @@ class LMSHelpdeskManager extends LMSManager implements LMSHelpdeskManagerInterfa
         return ($owner === '1');
     }
 
-    public function GetCategoryList($stats = true)
+    public function GetCategoryList($stats = true, $owners = true)
     {
-        if ($result = $this->db->GetAll('SELECT id, name, description, style
-				FROM rtcategories ORDER BY name')) {
-            if ($stats) {
-                foreach ($result as $idx => $row) {
-                    foreach ($this->GetCategoryStats($row['id']) as $sidx => $row2) {
-                        $result[$idx][$sidx] = $row2;
-                    }
-                }
-            }
-            foreach ($result as $idx => $category) {
-                $result[$idx]['owners'] = $this->db->GetAll('SELECT u.id, name FROM rtcategoryusers cu
-				LEFT JOIN vusers u ON cu.userid = u.id
-				WHERE categoryid = ?', array($category['id']));
+        $categories = $this->db->GetAll('
+            SELECT id, name, description, style
+                FROM rtcategories
+            ORDER BY name
+        ');
+
+        if (empty($categories)) {
+            return [];
+        }
+
+        $ownersByCategory = [];
+        if ($owners) {
+            $ownersList = $this->db->GetAll('
+            SELECT cu.categoryid, u.id, u.name, u.deleted,
+                (CASE WHEN u.access = 1 AND u.accessfrom <= ?NOW? AND (u.accessto >= ?NOW? OR u.accessto = 0) THEN 1 ELSE 0 END) AS access
+            FROM rtcategoryusers cu
+            LEFT JOIN vusers u ON cu.userid = u.id
+        ');
+
+            foreach ($ownersList as $owner) {
+                $catId = $owner['categoryid'];
+                unset($owner['categoryid']);
+                $ownersByCategory[$catId][] = $owner;
             }
         }
-        return $result;
+
+        foreach ($categories as &$category) {
+            if ($stats) {
+                $category += $this->GetCategoryStats($category['id']);
+            }
+            $category['owners'] = $ownersByCategory[$category['id']] ?? [];
+        }
+
+        return $categories;
     }
 
     public function GetCategoryStats($id)

--- a/lib/LMSManagers/LMSHelpdeskManagerInterface.php
+++ b/lib/LMSManagers/LMSHelpdeskManagerInterface.php
@@ -61,7 +61,7 @@ interface LMSHelpdeskManagerInterface
 
     public function GetUserRightsToCategory($user, $category, $ticket = null);
 
-    public function GetCategoryList($stats = true);
+    public function GetCategoryList($stats = true, $owners = true);
 
     public function GetCategoryStats($id);
 

--- a/lib/SmartyPlugins/LMSSmartyPlugins.php
+++ b/lib/SmartyPlugins/LMSSmartyPlugins.php
@@ -1401,6 +1401,36 @@ class LMSSmartyPlugins
             . '</select>';
     }
 
+    public static function userCompactListFunction(array $params, $template)
+    {
+        $default_user_row_limit = 4;
+
+        $elemid = $params['elemid'] ?? false;
+        $elemname = $params['elemname'] ?? false;
+        $class = $params['class'] ?? false;
+        $limit = empty($params['limit']) ? $default_user_row_limit : intval($params['limit']);
+        $userlist = empty($params['userlist']) ? trans('No avaiable users') : $params['userlist'];
+        $usercount = sizeof($userlist);
+        $ul = '';
+
+        foreach ($userlist as $item) {
+            $ul .= '<a href="?m=userinfo&id=' . $item['id'] . '" class="'
+                . (empty($item['deleted']) ? '' : 'crossed disabled')
+                . (empty($item['access']) ? ' blend' : '')
+                . (empty($item['class']) ? '' : ' ' . $class)
+                . '" style="font-weight: normal">'
+                . htmlspecialchars(substr(trans($item['name']), 0, 40))
+                . '</a><br>';
+        }
+
+        return '<div '
+            . ($elemname ? ' name="' . $elemname . '"' : '')
+            . ($elemid ? ' id="' . $elemid . '"' : '') . '>'
+            . ($usercount < $limit ?
+                $ul : self::hintFunction(array('content' => $ul, 'icon' => 'user'), $template) . $usercount)
+            . '</div>';
+    }
+
     public static function userSelectionFunction(array $params, $template)
     {
         static $userlist = array();

--- a/modules/eventlist.php
+++ b/modules/eventlist.php
@@ -38,6 +38,7 @@ $default_forward_day_limit = ConfigHelper::getConfig('timetable.default_forward_
 $hide_disabled_users = ConfigHelper::checkConfig('timetable.hide_disabled_users', ConfigHelper::checkConfig('phpui.timetable_hide_disabled_users'));
 $show_delayed_events = ConfigHelper::checkConfig('timetable.show_delayed_events', ConfigHelper::checkConfig('phpui.timetable_overdue_events'));
 $big_networks = ConfigHelper::checkConfig('phpui.big_networks');
+$user_row_limit = ConfigHelper::getConfig('timetable.row_user_limit', ConfigHelper::getConfig('phpui.timetable_user_row_limit', 4));
 $params['userid'] = Auth::GetCurrentUser();
 
 if (!empty($filter['edate'])) {
@@ -283,5 +284,6 @@ $SMARTY->assign(array(
     'getHolidays', getHolidays($year ?? null),
     'customerlist' => $big_networks ? null : $LMS->GetCustomerNames(),
     'divisions' => $LMS->GetDivisions(array('userid' => Auth::GetCurrentUser())),
+    'user_row_limit' => $user_row_limit,
 ));
 $SMARTY->display('event/eventlist.html');

--- a/templates/default/event/eventinfo.html
+++ b/templates/default/event/eventinfo.html
@@ -316,12 +316,7 @@
 					<strong>{trans("Users")}</strong>
 				</td>
 				<td class="nobr">
-					{foreach $event.userlist as $userid => $user}
-						<a href="?m=userinfo&id={$userid}">{$user.rname|escape}</a>
-						{if !$user@last}
-							<br>
-						{/if}
-					{/foreach}
+					{user_compact_list limit=$user_row_limit userlist=$event.userlist}
 				</td>
 			</tr>
 		{/if}

--- a/templates/default/event/eventlistboxrow.html
+++ b/templates/default/event/eventlistboxrow.html
@@ -15,7 +15,7 @@
             </a>
         {/if}
     </td>
-    <TD class="text-left nobr bold" style="min-width:100px" data-target-url="?m=eventinfo&id={$event.id}">
+    <TD class="text-left nobr bold" style="min-width:100px">
         {if $event.endtime == 86400}
             {trans("whole day")}
         {else}
@@ -28,25 +28,8 @@
         {if $overdue == 1}
             <br>{$event.date|date_format:"Y-m-d"}
         {/if}
-        {$imadded=0}
-        {$user_row_limit = intval(ConfigHelper::getConfig('timetable.row_user_limit', ConfigHelper::getConfig('phpui.timetable_user_row_limit', 4)))}
-        {if !empty($event.userlist)}
-            {if !$user_row_limit || count($event.userlist) <= $user_row_limit}
-                {foreach $event.userlist as $user}
-                    {if $layout.logid == $user.id}
-                        {$imadded=1}
-                    {/if}
-                    <br>
-                    <a href="?m=userinfo&amp;id={$user.id}"
-                       style="font-weight: normal;" {if isset($user.noaccess)} class="lms-ui-crossed"{/if}>{$user.name|trunescape:25}</a>
-                {/foreach}
-            {else}
-                <br>
-                <i class="lms-ui-icon-user lms-ui-hint-rollover"
-                   data-url="?m=eventinfoshort&id={$event.id}"></i>
-                {$event.userlist|@count}
-            {/if}
-        {/if}
+        {user_compact_list limit=$user_row_limit userlist=$event.userlist}
+        {$imadded = in_array($layout.logid, array_column($event.userlist, 'id'))}
     </TD>
     <TD data-target-url="?m=eventinfo&id={$event.id}">
         <a href="?m=eventinfo&id={$event.id}">

--- a/templates/default/rt/rtcategorylist.html
+++ b/templates/default/rt/rtcategorylist.html
@@ -1,6 +1,8 @@
 {extends file="layout.html"}
 {block name=title}LMS: {$layout.pagetitle|striphtml}{/block}
 {block name=module_content}
+{$user_row_limit = ConfigHelper::getConfig('rt.row_user_limit', 4)}
+
 <!-- $Id$ -->
 <h1>{$layout.pagetitle}</h1>
 <table class="lmsbox lms-ui-background-cycle">
@@ -59,9 +61,7 @@
 					</div>
 				</td>
 				<td class="lms-ui-buttons">
-					{foreach $category.owners as $key => $owner}
-						<a href="?m=userinfo&id={$owner.id}">{$owner.name}</a>{if $key+1<count($category.owners)}, {/if}
-					{/foreach}
+				{user_compact_list limit=$user_row_limit userlist=$category.owners}
 				</td>
 				<td class="text-center">
 					{$category.new|default:0}


### PR DESCRIPTION
Motywacja:
Rozjeżdżający się widok listy kategorii/terminarza na kilka stron list, psuł czytelność szczególnie przy wyborze "wszyscy" dla niektórych miejsc.

Po zmianie:
Lista kategorii:
<img width="2269" height="541" alt="image" src="https://github.com/user-attachments/assets/1a6c3440-2799-4063-870e-13071db6afe0" />

Terminarz:
![image](https://github.com/chilek/lms/assets/17087236/62173b73-f9ec-4093-b374-ec81825cb3ff)

Sterowanie zmiennymi `rt.row_user_limit` oraz `timetable.row_user_limit`