### PR TITLE
bugfix: Fix mysql migration, daemon buffer overflow, database backup recover

### DIFF
--- a/daemon/lmsd.c
+++ b/daemon/lmsd.c
@@ -113,8 +113,8 @@ int main(int argc, char *argv[], char **envp)
         str_replace(&driver, "postgres", "pgsql"); // postgres in ini file is pgsql
         str_replace(&driver, "mysqli", "mysql");   // mysqli in ini file is mysql
 
-        char dbdrv_path[strlen(LMS_LIB_DIR) + strlen(driver) + 4];
-        sprintf(dbdrv_path, LMS_LIB_DIR "/%s.so", driver);
+        char dbdrv_path[strlen(LMS_LIB_DIR) + strlen(driver) + 5];
+	snprintf(dbdrv_path, sizeof(dbdrv_path), "%s/%s.so", LMS_LIB_DIR, driver);
 
         if( !file_exists(dbdrv_path))
         {

--- a/lib/upgradedb/mysql.2022092200.php
+++ b/lib/upgradedb/mysql.2022092200.php
@@ -21,19 +21,10 @@
  *
  */
 
-define('CONTACT_NOTIFICATIONS_2022092201', 32);
-define('CONTACT_HELPDESK_NOTIFICATIONS_2022092201', 131072);
-
 $this->BeginTrans();
 
-$this->Execute(
-    "UPDATE customercontacts SET type = type | ? WHERE (type & ?) > 0",
-    array(
-        CONTACT_HELPDESK_NOTIFICATIONS_2022092201,
-        CONTACT_NOTIFICATIONS_2022092201,
-    )
-);
+$this->Execute("ALTER TABLE assignments ADD COLUMN paytime smallint DEFAULT NULL");
 
-$this->Execute("UPDATE dbinfo SET keyvalue = ? WHERE keytype = ?", array('2022092201', 'dbversion'));
+$this->Execute("UPDATE dbinfo SET keyvalue = ? WHERE keytype = ?", array('2022092200', 'dbversion'));
 
 $this->CommitTrans();

--- a/modules/dbrecover.php
+++ b/modules/dbrecover.php
@@ -121,7 +121,8 @@ if (isset($_GET['is_sure'])) {
     $layout['pagetitle'] = trans('Database Backup Recovery');
     $SMARTY->display('header.html');
     echo '<H1>'.trans('Database Backup Recovery').'</H1>';
-    echo '<P>'.trans('Are you sure, you want to recover database created at $a?', date('Y/m/d H:i.s', $_GET['db'])).'</P>';
+    $timestamp = explode('-', $_GET['db'])[0];
+    echo '<P>'.trans('Are you sure, you want to recover database created at $a?', date('Y/m/d H:i.s', $timestamp)).'</P>';
     echo '<A href="?m=dbrecover&db='.$_GET['db'].'&is_sure=1">'.trans('Yes, I am sure.').'</A>';
     $SMARTY->display('footer.html');
 }

--- a/templates/default/dblist.html
+++ b/templates/default/dblist.html
@@ -92,7 +92,7 @@
 		});
 		$('.recover-backup').click(function() {
 			confirmDialog($t("Are you sure, you want to restore this database backup?\n\nWARNING!\n\nIt will backup current database content automatically"), this).done(function() {
-				location.href = $(this).attr('href');
+				location.href = $(this).attr('href') + '&is_sure=1';
 			});
 			return false;
 		});


### PR DESCRIPTION
### Description
This Pull Request addresses several issues encountered during the LMS update (from the 2018 version to 2025).

### Fixes

- Revert accident changes on mysql migration to correct one
- Fix buffer overflow daemon crash (and slightly improve by using `snprintf` instead of `sprintf`)
- Fix `dbrecover.php` crash when `is_sure=1` is not set
- Restore `&is_sure=1` for recover-backup confirm dialog (`confirmDialog` is not doing it by default like previously used `confirmLink`)
