### PR TITLE
bugfix: missed sanitization allow to display bad words in userpanel

### DIFF
--- a/userpanel/index.php
+++ b/userpanel/index.php
@@ -253,8 +253,9 @@ $plugin_manager->executeHook('userpanel_smarty_initialized', $SMARTY);
 
 if ($SESSION->islogged) {
     $module = isset($_GET['m']) ? preg_replace('/[^a-zA-Z0-9_-]/', '', $_GET['m']) : '';
+    $function = preg_replace('/[^a-zA-Z0-9_-]/', '', $_GET['f'] ?? '');
     if ($SESSION->isPasswdChangeRequired) {
-        if ($module != 'info' && $_GET['f'] != 'updatepinform') {
+        if ($module != 'info' && $function != 'updatepinform') {
             $SESSION->close();
             header('Location: ?m=info&f=updatepinform');
             die;
@@ -296,7 +297,7 @@ if ($SESSION->islogged) {
 
         include($module_dir . $module . DIRECTORY_SEPARATOR . 'functions.php');
 
-        $function = isset($_GET['f']) && $_GET['f']!='' ? $_GET['f'] : 'main';
+        $function = $function ?: 'main';
         if (function_exists('module_'.$function)) {
             $to_execute = 'module_'.$function;
             $layout['userpanel_module'] = $module;


### PR DESCRIPTION
Natknąłem się na to debugując problem z wtyczką jambox.

Jakieś takie dowolne pierdolety można wyświetlać u klientów dając im spreparowany link:
<a href="https://ebok.wstawnazweisp.pl/?m=finances&f=ebok%3C/div%3E%3Ch1%3EZOSTA%C5%81E%C5%9A%20ZHAKOWANY%20FORMATUJE%20CI%20DYSKI%3C/h1%3E%3Cdiv%20style=%22color:%20white%22%3E%3E">zaloguj się do ebok</a>

Wygląda to tak:
![image](https://github.com/user-attachments/assets/3491a87f-c0fc-48e5-9c61-83e22d7ba936)