### PR TITLE
bugfix: missed tip in button causes no label in {buttons} menu

### DIFF
--- a/templates/default/rt/rtticketinfobox.html
+++ b/templates/default/rt/rtticketinfobox.html
@@ -507,7 +507,7 @@
 						data_confirmation_text=trans('Are you sure, you want to remove ticket $a?', $ticket.ticketid)
 					}
 				{/if}
-				{button icon="link" class="lms-ui-button-clipboard" label="Copy link" data_clipboard_text=$ticketinfo_clipboard_text}
+				{button icon="link" class="lms-ui-button-clipboard" label="Copy link" data_clipboard_text=$ticketinfo_clipboard_text tip="Copy link"}
 			{/buttons}
 		</TD>
 	</TR>


### PR DESCRIPTION
Przed:
<img width="1396" height="774" alt="image" src="https://github.com/user-attachments/assets/c15c41ef-d3d4-4dac-a7c1-3f32866e6c67" />

Po:
<img width="1396" height="774" alt="image" src="https://github.com/user-attachments/assets/a0b63936-43f2-4192-9c99-d0b4a3febaf3" />