### PR TITLE
bugfix: ui, propper vertical align labels/icons of buttons/nav-links …

### DIFF
--- a/userpanel/style/bclean/body.html
+++ b/userpanel/style/bclean/body.html
@@ -32,8 +32,7 @@
 				{foreach $menuitems as $menuitem}
 					<li class="nav-item {if strpos($smarty.get.m, $menuitem.module) !== false && strlen($smarty.get.m)==strlen($menuitem.module) }active{/if}">
 						<a class="nav-link" href="?m={$menuitem.module}" id="lms-userpanel-menu-item-{$menuitem.module}" {userpaneltip text=$menuitem.tip}>
-							{if $menuitem.icon}<i class="{$menuitem.icon}"></i>{/if}
-							{$menuitem.name|replace:" ":"&nbsp;"}
+							{icon name=$menuitem.icon label="{$menuitem.name|replace:" ":"&nbsp;"}"}
 							<i class="warning-icon"></i>
 						</a>
 					</li>

--- a/userpanel/style/bclean/style.less
+++ b/userpanel/style/bclean/style.less
@@ -158,9 +158,22 @@ nav.navbar {
     vertical-align: middle;
 }
 i + .lms-ui-label {
-    padding-left: 0.5em;
+    padding-left: 0.35em;
 }
 
 .table td, .table th {
     vertical-align: middle;
+}
+
+.lms-ui-button,
+.navbar .nav-link {
+    display: inline-flex;
+    align-items: center;
+    line-height: 1.5;
+    padding-left: 0.8em;
+    padding-right: 0.8em;
+}
+
+.navbar .nav-link i {
+    margin-right: 0.4em;
 }


### PR DESCRIPTION
…(bclean style)

Przed:
<img width="1695" height="497" alt="image" src="https://github.com/user-attachments/assets/5443479c-8548-4043-a768-99f35c4f12d7" />
<img width="886" height="751" alt="image" src="https://github.com/user-attachments/assets/3ebbe64e-ea43-43c7-bf10-9b68ecd0f533" />
<img width="586" height="236" alt="image" src="https://github.com/user-attachments/assets/ac5ee581-da23-4baf-9199-63d82ca54133" />


Po:
<img width="1771" height="520" alt="image" src="https://github.com/user-attachments/assets/ad14b0da-8461-40e7-a1c1-bef6c3cdef35" />
<img width="886" height="751" alt="image" src="https://github.com/user-attachments/assets/a788dc29-d435-4d57-9666-91637d0160e2" />
<img width="586" height="236" alt="image" src="https://github.com/user-attachments/assets/94ae7dad-e1e7-4d0d-ae45-faef7c005157" />
