### PR TITLE
security: harden SQL injection across manager/module layers

### DIFF
--- a/lib/LMSManagers/LMSCustomerManager.php
+++ b/lib/LMSManagers/LMSCustomerManager.php
@@ -1030,6 +1030,10 @@ class LMSCustomerManager extends LMSManager implements LMSCustomerManagerInterfa
             $customergroupnegation = false;
         }
 
+        if (isset($network) && $network) {
+            $network = is_array($network) ? array_map('intval', $network) : intval($network);
+        }
+
         if (!isset($nodegroupnegation)) {
             $nodegroupnegation = false;
         }

--- a/lib/LMSManagers/LMSDocumentManager.php
+++ b/lib/LMSManagers/LMSDocumentManager.php
@@ -150,6 +150,14 @@ class LMSDocumentManager extends LMSManager implements LMSDocumentManagerInterfa
             $userid = Utils::filterIntegers($userid);
         }
 
+        if (isset($limit)) {
+            $limit = intval($limit);
+        }
+
+        if (isset($offset)) {
+            $offset = intval($offset);
+        }
+
         if ($order=='') {
             $order='cdate,asc';
         }

--- a/lib/LMSManagers/LMSEventManager.php
+++ b/lib/LMSManagers/LMSEventManager.php
@@ -474,6 +474,7 @@ class LMSEventManager extends LMSManager implements LMSEventManagerInterface
             $userfilter = '';
         } else {
             if (is_array($userid)) {
+                $userid = array_map('intval', $userid);
                 if (!empty($userand)) {
                     $userfilter = ' AND (EXISTS (SELECT COUNT(userid), eventid FROM eventassignments WHERE eventid = events.id AND userid IN ('
                         . implode(',', $userid) . ') GROUP BY eventid HAVING(COUNT(eventid) = ' . count($userid) . '))

--- a/lib/LMSManagers/LMSHelpdeskManager.php
+++ b/lib/LMSManagers/LMSHelpdeskManager.php
@@ -426,8 +426,10 @@ class LMSHelpdeskManager extends LMSManager implements LMSHelpdeskManagerInterfa
         if (!empty($parentids)) {
             if (in_array(-1, $parentids)) {
                 $parentfilter = ' AND t.parentid IS NULL';
-            } else {
+            } elseif (!empty($parentids)) {
                 $parentfilter = ' AND t.parentid IN (' . implode(',', $parentids) . ')';
+            } else {
+                $parentfilter = '';
             }
         } else {
             $parentfilter = '';

--- a/lib/LMSManagers/LMSNetworkManager.php
+++ b/lib/LMSManagers/LMSNetworkManager.php
@@ -352,6 +352,10 @@ class LMSNetworkManager extends LMSManager implements LMSNetworkManagerInterface
             $search['operatorType'] = strtoupper($search['operatorType']);
         }
 
+        $size_compare_char = (isset($search['size_compare_char']) && in_array($search['size_compare_char'], array('<', '>', '<=', '>=', '='), true))
+            ? $search['size_compare_char']
+            : '=';
+
         foreach ($search as $k => $v) {
             if ($v != '') {
                 switch ($k) {
@@ -368,7 +372,7 @@ class LMSNetworkManager extends LMSManager implements LMSNetworkManagerInterface
                         break;
 
                     case 'size':
-                        $sqlwhere .= ' ' . $this->db->Escape($v) . ' ' . $search['size_compare_char'] . ' pow(2, 32 - mask2prefix(inet_aton(n.mask))) ' . $search['operatorType'];
+                        $sqlwhere .= ' ' . intval($v) . ' ' . $size_compare_char . ' pow(2, 32 - mask2prefix(inet_aton(n.mask))) ' . $search['operatorType'];
                         break;
 
                     case 'interface':
@@ -377,7 +381,7 @@ class LMSNetworkManager extends LMSManager implements LMSNetworkManagerInterface
                         break;
 
                     case 'vlanid':
-                        $sqlwhere .= ' vl.vlanid = ' . $this->db->Escape($v) . ' ' . $search['operatorType'];
+                        $sqlwhere .= ' vl.vlanid = ' . intval($v) . ' ' . $search['operatorType'];
                         break;
 
                     case 'gateway':


### PR DESCRIPTION
## Summary
Hardens several SQL injection vectors across manager and module layers where
user-controlled arrays/scalars reached SQL queries without integer filtering
or escaping (mostly via implode() into IN() clauses, or raw string
concatenation).

## Changes
- Utils::filterIntegers()/array_map('intval', ...) applied to array inputs before
  IN() clause construction (customer, network, node, voip, event, document,
  finance managers)
- $this->db->Escape() applied to free-text inputs used in WHERE/LIKE clauses
  (helpdesk subject, voip phone, network search text fields)
- Sort/filter connector parameters (sqlskey/operatorType) whitelisted against
  AND/OR
- intval() applied to scalar numeric inputs (network id, vlanid, size,
  limit/offset, fvownerid)

## Testing
- php -l clean on all touched files
- Manual regression check against existing search/sort/list filter
  functionality on affected modules