### PR TITLE
bugfix: fix typo breaking multi-value parentids filter in LMSHelpdeskManager

### DIFF
--- a/lib/LMSManagers/LMSHelpdeskManager.php
+++ b/lib/LMSManagers/LMSHelpdeskManager.php
@@ -417,7 +417,7 @@ class LMSHelpdeskManager extends LMSManager implements LMSHelpdeskManagerInterfa
         }
 
         if (!empty($parentids)) {
-            if (!is_array($parrentids)) {
+            if (!is_array($parentids)) {
                 $parentids = array($parentids);
             }
             $parentids = Utils::filterIntegers($parentids);


### PR DESCRIPTION
Typo introduced in 1a8e6e95e ("bugfix: security: fixed some sql injection errors", 2026-08-06): `$parrentids` is never defined anywhere in the file, so `!is_array($parrentids)` is always `true`. This double-wraps an already-array $parentids before Utils::filterIntegers(), breaking ticket filtering by multiple parent ids. Filtering by a single parent id is unaffected. One-line fix: correct the variable name.