### PR TITLE
security: whitelist size_compare_char in network search (SQL syntax injection)

### DIFF
--- a/lib/LMSManagers/LMSNetworkManager.php
+++ b/lib/LMSManagers/LMSNetworkManager.php
@@ -352,6 +352,10 @@ class LMSNetworkManager extends LMSManager implements LMSNetworkManagerInterface
             $search['operatorType'] = strtoupper($search['operatorType']);
         }
 
+        $size_compare_char = (isset($search['size_compare_char']) && in_array($search['size_compare_char'], array('<', '>', '<=', '>=', '=', '<>'), true))
+            ? $search['size_compare_char']
+            : '=';
+
         foreach ($search as $k => $v) {
             if ($v != '') {
                 switch ($k) {
@@ -368,7 +372,7 @@ class LMSNetworkManager extends LMSManager implements LMSNetworkManagerInterface
                         break;
 
                     case 'size':
-                        $sqlwhere .= ' ' . $this->db->Escape($v) . ' ' . $search['size_compare_char'] . ' pow(2, 32 - mask2prefix(inet_aton(n.mask))) ' . $search['operatorType'];
+                        $sqlwhere .= ' ' . $this->db->Escape($v) . ' ' . $size_compare_char . ' pow(2, 32 - mask2prefix(inet_aton(n.mask))) ' . $search['operatorType'];
                         break;
 
                     case 'interface':


### PR DESCRIPTION
`search[size_compare_char]` is interpolated directly as a comparison operator in the network-size filter query (LMSNetworkManager::GetNetworkList, case 'size'), not escaped as a value — `Escape()` cannot protect a syntax fragment. Whitelisted to the 6 values the UI actually offers ({<,>,<=,>=,=,<>} per templates/default/net/netsearch.html), defaulting to '=' for anything else.

Confirmed via adversarial audit that this is the only remaining gap after the independent SQLi hardening already merged upstream (1a8e6e95e and related commits, 2026-08-06). Supersedes #2512, which is otherwise redundant with upstream's own fixes.